### PR TITLE
Add missing namespace

### DIFF
--- a/docs/1. Create BackEnd API project.md
+++ b/docs/1. Create BackEnd API project.md
@@ -16,6 +16,7 @@
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.EntityFrameworkCore.Design;
 
     namespace BackEnd.Models
     {


### PR DESCRIPTION
So that `IDesignTimeDbContextFactory` will be recognized when copy/pasting.